### PR TITLE
Update networks.js

### DIFF
--- a/networks.js
+++ b/networks.js
@@ -8,7 +8,7 @@ exports.livenet = {
     name: 'livenet',
     magic: hex('fbc0b6db'),
     addressVersion: 55,
-    privKeyVersion: 189,
+    privKeyVersion: 183,
     P2SHVersion: 5,
     hkeyPublicVersion: 0x0488b21e,
     hkeyPrivateVersion: 0x0488ade4,


### PR DESCRIPTION
183 should be the right number.

The private keys generated using 183 can be imported into the daemon, those generated with 189 cannot.
.... how ever transactions, still being rejected, but that is due signing issues.